### PR TITLE
Add js redirect for old github.io domain

### DIFF
--- a/_includes/js.html
+++ b/_includes/js.html
@@ -11,3 +11,4 @@
 <script src="/js/landing-page.js"></script>
 <script src="/js/markdown.js"></script>
 <script src="/js/github.js"></script>
+<script src="/js/redirect.js"></script>

--- a/js/redirect.js
+++ b/js/redirect.js
@@ -1,0 +1,7 @@
+$(document).ready(function () {
+  // This is a hack that our old github.io URL redirects to our new 101.o.o
+  //if(window.location.href.indexOf('github.io') > -1){
+  if(window.location.href.indexOf('github.io') > -1){
+    window.location.replace('http://101.opensuse.org/');
+  }
+});


### PR DESCRIPTION
This is a hack that the old URL still works which we already distributed.