### PR TITLE
Resture Other projects section

### DIFF
--- a/_posts/2018-01-30-project-others.markdown
+++ b/_posts/2018-01-30-project-others.markdown
@@ -1,0 +1,10 @@
+---
+layout: default
+img: openSUSE.png
+title: Others
+type: project
+technologies: [FOSS, Programming]
+website: http://opensuse.org
+github: https://github.com/openSUSE
+---
+In this section, we list all projects that do not fit in one of the other areas.


### PR DESCRIPTION
It was removed in db42376 but now the following project is not shown: https://github.com/openSUSE/mentoring/issues/100

So I think we should restart it to give it more visibility to that project. 😉 