### PR TITLE
Add trailing slash to GSoC links

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -21,7 +21,7 @@
                     </li>
                     <li class="footer-menu-divider">&sdot;</li>
                     <li>
-                        <a href="/gsoc">GSoC</a>
+                        <a href="/gsoc/">GSoC</a>
                     </li>
                 </ul>
                 <p class="copyright text-muted small">{{ site.copyright }}</p>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -24,7 +24,7 @@
                     <a class="page-scroll" href="#mentor">Mentor</a>
                 </li>
                 <li>
-                    <a class="page-scroll" href="/gsoc">GSoC</a>
+                    <a class="page-scroll" href="/gsoc/">GSoC</a>
                 </li>
             </ul>
         </div>

--- a/js/github.js
+++ b/js/github.js
@@ -68,7 +68,7 @@ function get_gsoc_hint(labels){
         url = current_url;
       }
       else{
-        url = current_url + "/gsoc";
+        url = current_url + "/gsoc/";
       }
       result = "<p>You can do this project as part of the Google Summer of Code program. Click <a href='" + url + "'>here</a> for more information.</p>"
       break;


### PR DESCRIPTION
Fixes #107. Not sure what's wrong with the deployment, but at least let's fix the link.