### PR TITLE
Set up matomo for mentoring

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,6 +12,7 @@ copyright: 'Copyright &copy; 2015-2020 openSUSE. All Rights Reserved.'
 github_organization: openSUSE
 github_repository: mentoring
 github_url: "https://github.com/openSUSE/mentoring"
+piwik_site_id: 34
 plugins:
   - jekyll-redirect-from
 # ----------------------- #


### PR DESCRIPTION
We have matomo setup at beans.opensuse.org, it would be nice to monitor traffic to this site